### PR TITLE
Fix Webcron URL + Description

### DIFF
--- a/administrator/components/com_scheduler/src/Task/Task.php
+++ b/administrator/components/com_scheduler/src/Task/Task.php
@@ -194,7 +194,7 @@ class Task extends Registry implements LoggerAwareInterface
 
 		// @todo make the ExecRuleHelper usage less ugly, perhaps it should be composed into Task
 		// Update object state.
-		$this->set('last_execution', Factory::getDate('@' . $this->snapshot['taskStart'])->toSql());
+		$this->set('last_execution', Factory::getDate('@' . (int) $this->snapshot['taskStart'])->toSql());
 		$this->set('next_execution', (new ExecRuleHelper($this->toObject()))->nextExec());
 		$this->set('last_exit_code', $this->snapshot['status']);
 		$this->set('times_executed', $this->get('times_executed') + 1);

--- a/administrator/language/en-GB/com_scheduler.ini
+++ b/administrator/language/en-GB/com_scheduler.ini
@@ -9,7 +9,7 @@ COM_SCHEDULER_CONFIG_FIELDSET_LAZY_SCHEDULER_DESC="Configure how site visits tri
 COM_SCHEDULER_CONFIG_FIELDSET_LAZY_SCHEDULER_LABEL="Lazy Scheduler"
 COM_SCHEDULER_CONFIG_GENERATE_WEBCRON_KEY_DESC="The webcron needs a protection key before it is functional. Saving this configuration will autogenerate the key."
 COM_SCHEDULER_CONFIG_GLOBAL_WEBCRON_KEY_LABEL="Global Key"
-COM_SCHEDULER_CONFIG_GLOBAL_WEBCRON_LINK_DESC="By default, requesting this base link will only run tasks due for execution. To execute a specific task, use the task's ID as a query parameter appended to the URL: <code>BASE_URL&task_id=&lttask's id&gt</code>"
+COM_SCHEDULER_CONFIG_GLOBAL_WEBCRON_LINK_DESC="By default, requesting this base link will only run tasks due for execution. To execute a specific task, use the task's ID as a query parameter appended to the URL: <code>BASE_URL&id=&lttask's id&gt</code>"
 COM_SCHEDULER_CONFIG_GLOBAL_WEBCRON_LINK_LABEL="Webcron Link (Base)"
 COM_SCHEDULER_CONFIG_HASH_PROTECTION_DESC="If enabled, tasks will only be triggered when URLs have the scheduler hash as a parameter."
 COM_SCHEDULER_CONFIG_LAZY_SCHEDULER_ENABLED_DESC="If disabled, scheduled tasks will not be triggered by visitors on the site.<br>Recommended if triggering with native cron."

--- a/plugins/system/schedulerunner/schedulerunner.php
+++ b/plugins/system/schedulerunner/schedulerunner.php
@@ -267,7 +267,7 @@ class PlgSystemSchedulerunner extends CMSPlugin implements SubscriberInterface
 		{
 			$form->removeField('generate_key_on_save', 'webcron');
 
-			$relative = 'index.php?option=com_ajax&plugin=RunSchedulerLazy&group=system&format=json&hash=' . $data['webcron']['key'];
+			$relative = 'index.php?option=com_ajax&plugin=RunSchedulerWebcron&group=system&format=json&hash=' . $data['webcron']['key'];
 			$link = Route::link('site', $relative, false, Route::TLS_IGNORE, true);
 			$form->setValue('base_link', 'webcron', $link);
 		}


### PR DESCRIPTION
Pull Request for Issue #37 .

### Summary of Changes
Fixes Web cron URL, description as exposed in the scheduler component config.


### Testing Instructions
1. Go to the Scheduler component config > Webcron tab > Webcron base link.
2. Check the base link + the description.

### Actual result BEFORE applying this Pull Request
- URL: https://example.com/index.php/component/ajax/?plugin=RunSchedulerLazy&group=system&format=json&hash=APyjF9VOQEPdLeNdsw2E

- Description: `BASE_URL&task_id=<task's id>`


### Expected result AFTER applying this Pull Request
- URL (fixed plugin param): https://example.com/index.php/component/ajax/?plugin=RunSchedulerWebcron&group=system&format=json&hash=APyjF9VOQEPdLeNdsw2E

- Description (fixed id param): `BASE_URL&id=<task's id>`
