### PR TITLE
Use an injected logger in the Task driver

### DIFF
--- a/administrator/components/com_associations/src/Controller/AssociationsController.php
+++ b/administrator/components/com_associations/src/Controller/AssociationsController.php
@@ -91,8 +91,6 @@ class AssociationsController extends AdminController
 		$this->setRedirect(Route::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false));
 
 		// Figure out if the item supports checking and check it in
-		$type = null;
-
 		list($extensionName, $typeName) = explode('.', $this->input->get('itemtype'));
 
 		$extension = AssociationsHelper::getSupportedExtension($extensionName);

--- a/administrator/components/com_config/src/View/Application/HtmlView.php
+++ b/administrator/components/com_config/src/View/Application/HtmlView.php
@@ -61,9 +61,6 @@ class HtmlView extends BaseHtmlView
 	 */
 	public function display($tpl = null)
 	{
-		$form = null;
-		$data = null;
-
 		try
 		{
 			// Load Form and Data

--- a/administrator/components/com_config/src/View/Component/HtmlView.php
+++ b/administrator/components/com_config/src/View/Component/HtmlView.php
@@ -60,9 +60,6 @@ class HtmlView extends BaseHtmlView
 	 */
 	public function display($tpl = null)
 	{
-		$form = null;
-		$component = null;
-
 		try
 		{
 			$component = $this->get('component');

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -27,7 +27,6 @@ use Joomla\CMS\MVC\Model\WorkflowBehaviorTrait;
 use Joomla\CMS\MVC\Model\WorkflowModelInterface;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\String\PunycodeHelper;
-use Joomla\CMS\Table\Table;
 use Joomla\CMS\Table\TableInterface;
 use Joomla\CMS\Tag\TaggableTableInterface;
 use Joomla\CMS\UCM\UCMType;

--- a/administrator/components/com_media/src/Controller/PluginController.php
+++ b/administrator/components/com_media/src/Controller/PluginController.php
@@ -77,7 +77,6 @@ class PluginController extends BaseController
 			}
 
 			$action  = $eventResults['action'] ?? null;
-			$message = null;
 
 			// If there are any messages display them
 			if (isset($eventResults['message']))

--- a/administrator/components/com_menus/src/Controller/AjaxController.php
+++ b/administrator/components/com_menus/src/Controller/AjaxController.php
@@ -46,8 +46,6 @@ class AjaxController extends BaseController
 		}
 		else
 		{
-			$extension = $this->input->get('extension');
-
 			$assocId   = $this->input->getInt('assocId', 0);
 
 			if ($assocId == 0)

--- a/administrator/components/com_scheduler/src/Extension/SchedulerComponent.php
+++ b/administrator/components/com_scheduler/src/Extension/SchedulerComponent.php
@@ -21,7 +21,6 @@ use Psr\Container\ContainerInterface;
  * Component class for com_scheduler.
  *
  * @since  4.1.0
- * @todo   Set up logger(s) here.
  */
 class SchedulerComponent extends MVCComponent implements BootableExtensionInterface
 {

--- a/administrator/components/com_scheduler/src/Scheduler/Scheduler.php
+++ b/administrator/components/com_scheduler/src/Scheduler/Scheduler.php
@@ -15,12 +15,14 @@ namespace Joomla\Component\Scheduler\Administrator\Scheduler;
 use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\DelegatingPsrLogger;
 use Joomla\CMS\Log\Log;
 use Joomla\Component\Scheduler\Administrator\Extension\SchedulerComponent;
 use Joomla\Component\Scheduler\Administrator\Model\TaskModel;
 use Joomla\Component\Scheduler\Administrator\Model\TasksModel;
 use Joomla\Component\Scheduler\Administrator\Task\Status;
 use Joomla\Component\Scheduler\Administrator\Task\Task;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\OptionsResolver\Exception\AccessException;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
@@ -127,14 +129,17 @@ class Scheduler
 
 		$app->getLanguage()->load('com_scheduler', JPATH_ADMINISTRATOR);
 
-		$options['text_entry_format'] = '{DATE}	{TIME}	{PRIORITY}	{MESSAGE}';
-		$options['text_file']         = 'joomla_scheduler.php';
-		Log::addLogger($options, Log::ALL, $task->logCategory);
+		$loggerOptions = [
+			'text_entry_format' => '{DATE}	{TIME}	{PRIORITY}	{MESSAGE}',
+			'text_file'         => 'joomla_scheduler.php'
+		];
+		/** ! No non-static methods to add a sub-logger to {@see DelegatingPsrLogger} (Task::logger) */
+		Log::addLogger($loggerOptions, Log::ALL, $task->logCategory);
 
 		$taskId    = $task->get('id');
 		$taskTitle = $task->get('title');
 
-		$task->log(Text::sprintf('COM_SCHEDULER_SCHEDULER_TASK_START', $taskId, $taskTitle), 'info');
+		$task->log(Text::sprintf('COM_SCHEDULER_SCHEDULER_TASK_START', $taskId, $taskTitle));
 
 		// Let's try to avoid time-outs
 		if (\function_exists('set_time_limit'))

--- a/administrator/components/com_scheduler/src/Scheduler/Scheduler.php
+++ b/administrator/components/com_scheduler/src/Scheduler/Scheduler.php
@@ -255,7 +255,7 @@ class Scheduler
 			return null;
 		}
 
-		return new Task($task);
+		return new Task($task, Factory::getContainer()->get(LoggerInterface::class));
 	}
 
 	/**

--- a/administrator/components/com_scheduler/src/Task/Task.php
+++ b/administrator/components/com_scheduler/src/Task/Task.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Event\AbstractEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\DelegatingPsrLogger;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Component\Scheduler\Administrator\Event\ExecuteTaskEvent;
@@ -32,6 +33,7 @@ use Joomla\Utilities\ArrayHelper;
 use Psr\Log\InvalidArgumentException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
 
 /**
  * The Task class defines methods for the execution, logging and
@@ -129,7 +131,7 @@ class Task implements LoggerAwareInterface
 	 * @since 4.1.0
 	 * @throws \Exception
 	 */
-	public function __construct(object $record)
+	public function __construct(object $record, LoggerInterface $logger)
 	{
 		// Workaround because Registry dumps private properties otherwise.
 		$taskOption     = $record->taskOption;
@@ -140,17 +142,24 @@ class Task implements LoggerAwareInterface
 		$this->set('taskOption', $taskOption);
 		$this->app = Factory::getApplication();
 		$this->db  = Factory::getContainer()->get(DatabaseDriver::class);
-		$this->setLogger(Log::createDelegatedLogger());
+
+		$this->setLogger($logger);
 		$this->logCategory = 'task' . $this->get('id');
 
+		// ! We use an "injected" logger but still need a static {@see Log} call to set up sub-loggers :/
 		if ($this->get('params.individual_log'))
 		{
 			$logFile = $this->get('params.log_file') ?? 'task_' . $this->get('id') . '.log.php';
 
 			$options['text_entry_format'] = '{DATE}	{TIME}	{PRIORITY}	{MESSAGE}';
 			$options['text_file']         = $logFile;
+
+			/** No non-static methods on {@see DelegatingPsrLogger} to set up sub-loggers... */
 			Log::addLogger($options, Log::ALL, [$this->logCategory]);
 		}
+
+		// We need `com_scheduler` language strings for logging
+		$this->app->getLanguage()->load('com_scheduler', JPATH_ADMINISTRATOR);
 	}
 
 	/**
@@ -417,6 +426,8 @@ class Task implements LoggerAwareInterface
 	}
 
 	/**
+	 * Log a message with the task logger.
+	 *
 	 * @param   string  $message   Log message
 	 * @param   string  $priority  Log level, defaults to 'info'
 	 *

--- a/administrator/components/com_scheduler/src/Task/Task.php
+++ b/administrator/components/com_scheduler/src/Task/Task.php
@@ -229,6 +229,7 @@ class Task implements LoggerAwareInterface
 				'routineId'       => $this->get('type'),
 				'langConstPrefix' => $this->get('taskOption')->langConstPrefix,
 				'params'          => $this->get('params'),
+				'logger'		  => [$this, 'log']
 			]
 		);
 

--- a/administrator/components/com_scheduler/src/Task/Task.php
+++ b/administrator/components/com_scheduler/src/Task/Task.php
@@ -126,7 +126,8 @@ class Task implements LoggerAwareInterface
 	/**
 	 * Constructor for {@see Task}.
 	 *
-	 * @param   object  $record  A task from {@see TaskTable}.
+	 * @param   object           $record  A task from {@see TaskTable}.
+	 * @param   LoggerInterface  $logger  A logger instance for the Task's logs.
 	 *
 	 * @since 4.1.0
 	 * @throws \Exception
@@ -229,7 +230,7 @@ class Task implements LoggerAwareInterface
 				'routineId'       => $this->get('type'),
 				'langConstPrefix' => $this->get('taskOption')->langConstPrefix,
 				'params'          => $this->get('params'),
-				'logger'		  => [$this, 'log']
+				'logger'		  => [$this, 'log'],
 			]
 		);
 

--- a/administrator/components/com_scheduler/src/Traits/TaskPluginTrait.php
+++ b/administrator/components/com_scheduler/src/Traits/TaskPluginTrait.php
@@ -15,8 +15,6 @@ namespace Joomla\Component\Scheduler\Administrator\Traits;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Form\Form;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Log\Log;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\Component\Scheduler\Administrator\Event\ExecuteTaskEvent;
 use Joomla\Component\Scheduler\Administrator\Task\Status;
@@ -45,8 +43,19 @@ trait TaskPluginTrait
 	 */
 	protected $snapshot = [];
 
+
 	/**
-	 * Set information to {@see $snapshot} when initializing a routine.
+	 * The task logger. We expect this logger from {@see ExecuteTaskEvent}, setting it up in {@see startRoutine}.
+	 *
+	 * @var   callable {@signature (string $message, string $level = 'info'): void}
+	 * @since __DEPLOY__VERSION__
+	 * @todo  update doc once phpDocumentor adds callable signature support:
+	 *        {@link https://github.com/phpDocumentor/phpDocumentor/issues/1712}.
+	 */
+	protected $logger;
+
+	/**
+	 * Setup injected dependencies and {@see $snapshot} on routine initialisation.
 	 *
 	 * @param   ExecuteTaskEvent  $event  The onExecuteTask event.
 	 *
@@ -60,6 +69,8 @@ trait TaskPluginTrait
 		{
 			return;
 		}
+
+		$this->logger = $event->getArgument('logger');
 
 		$this->snapshot['logCategory'] = $event->getArgument('subject')->logCategory;
 		$this->snapshot['plugin']      = $this->_name;
@@ -233,30 +244,16 @@ trait TaskPluginTrait
 	 * @return void
 	 *
 	 * @since  4.1.0
-	 * @throws \Exception
-	 * @todo   : use dependency injection here (starting from the Task & Scheduler classes).
+	 * @throws \LogicException|\InvalidArgumentException
 	 */
 	protected function logTask(string $message, string $priority = 'info'): void
 	{
-		static $langLoaded;
-		static $priorityMap = [
-			'debug'   => Log::DEBUG,
-			'error'   => Log::ERROR,
-			'info'    => Log::INFO,
-			'notice'  => Log::NOTICE,
-			'warning' => Log::WARNING,
-		];
-
-		if (!$langLoaded)
+		if (empty($this->logger))
 		{
-			$app = $this->app ?? Factory::getApplication();
-			$app->getLanguage()->load('com_scheduler', JPATH_ADMINISTRATOR);
-			$langLoaded = true;
+			throw new \LogicException("Logger has not been setup!");
 		}
 
-		$category = $this->snapshot['logCategory'];
-
-		Log::add(Text::_('COM_SCHEDULER_ROUTINE_LOG_PREFIX') . $message, $priorityMap[$priority] ?? Log::INFO, $category);
+		($this->logger)($message, $priority);
 	}
 
 	/**

--- a/administrator/components/com_scheduler/src/Traits/TaskPluginTrait.php
+++ b/administrator/components/com_scheduler/src/Traits/TaskPluginTrait.php
@@ -43,7 +43,6 @@ trait TaskPluginTrait
 	 */
 	protected $snapshot = [];
 
-
 	/**
 	 * The task logger. We expect this logger from {@see ExecuteTaskEvent}, setting it up in {@see startRoutine}.
 	 *

--- a/components/com_contact/src/View/Contact/HtmlView.php
+++ b/components/com_contact/src/View/Contact/HtmlView.php
@@ -13,7 +13,6 @@ namespace Joomla\Component\Contact\Site\View\Contact;
 
 use Joomla\CMS\Categories\Categories;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Helper\TagsHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -145,7 +145,6 @@ final class SiteApplication extends CMSApplication
 
 		// Set up the params
 		$document = $this->getDocument();
-		$router   = static::getRouter();
 		$params   = $this->getParams();
 
 		// Register the document object with Factory
@@ -154,9 +153,8 @@ final class SiteApplication extends CMSApplication
 		switch ($document->getType())
 		{
 			case 'html':
-				// Get language
-				$lang_code = $this->getLanguage()->getTag();
-				$languages = LanguageHelper::getLanguages('lang_code');
+				// Set up the language
+				LanguageHelper::getLanguages('lang_code');
 
 				// Set metadata
 				$document->setMetaData('rights', $this->get('MetaRights'));

--- a/libraries/src/Editor/Editor.php
+++ b/libraries/src/Editor/Editor.php
@@ -183,8 +183,6 @@ class Editor implements DispatcherAwareInterface
 		$width = str_replace(';', '', $width);
 		$height = str_replace(';', '', $height);
 
-		$return = null;
-
 		$args['name'] = $name;
 		$args['content'] = $html;
 		$args['width'] = $width;

--- a/libraries/src/Form/Field/ColorField.php
+++ b/libraries/src/Form/Field/ColorField.php
@@ -341,7 +341,7 @@ class ColorField extends FormField
 			}
 		}
 
-		$split = $this->split ? $this->split : 3;
+		$split = $this->split ?: 3;
 
 		return array(
 			'colors' => $colors,

--- a/libraries/src/Form/Field/MediaField.php
+++ b/libraries/src/Form/Field/MediaField.php
@@ -336,7 +336,7 @@ class MediaField extends FormField
 
 		$mediaTypes   = array_map('trim', explode(',', $this->types));
 		$types        = [];
-		$imagesExt    = $imagesExt = array_map(
+		$imagesExt    = array_map(
 			'trim',
 			explode(
 				',',

--- a/libraries/src/Form/Field/RulesField.php
+++ b/libraries/src/Form/Field/RulesField.php
@@ -190,7 +190,6 @@ class RulesField extends FormField
 		// Note that for global configuration, com_config injects asset_id = 1 into the form.
 		$this->assetId = (int) $this->form->getValue($assetField);
 		$this->newItem = empty($this->assetId) && $this->isGlobalConfig === false && $section !== 'component';
-		$parentAssetId = null;
 
 		// If the asset id is empty (component or new item).
 		if (empty($this->assetId))

--- a/libraries/src/Router/ApiRouter.php
+++ b/libraries/src/Router/ApiRouter.php
@@ -209,7 +209,7 @@ class ApiRouter extends Router
 		// Extract routes matching $routePath from all known routes.
 		return array_filter($this->routes,
 			function ($route) use ($routePath) {
-				return preg_match($route->getRegex(), ltrim($routePath, '/'), $matches) === 1;
+				return preg_match($route->getRegex(), ltrim($routePath, '/')) === 1;
 			}
 		);
 	}

--- a/plugins/editors/none/none.php
+++ b/plugins/editors/none/none.php
@@ -86,8 +86,6 @@ class PlgEditorNone extends CMSPlugin
 	 */
 	public function _displayButtons($name, $buttons, $asset, $author)
 	{
-		$return = '';
-
 		if (is_array($buttons) || (is_bool($buttons) && $buttons))
 		{
 			$buttonsEvent = new Event(

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -766,7 +766,7 @@ class PlgSampledataBlog extends CMSPlugin
 				&& ComponentHelper::getParams('com_content')->get('workflow_enabled'))
 			{
 				// Set the article featured in #__content_frontpage
-				$query = $this->db->getQuery(true);
+				$this->db->getQuery(true);
 
 				$featuredItem = (object) [
 					'content_id'      => $articleModel->getItem()->id,

--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -260,7 +260,7 @@ class PlgSystemCache extends CMSPlugin
 					if ($exclusion !== '')
 					{
 						// Test both external and internal URI
-						if (preg_match('#' . $exclusion . '#i', $this->_cache_key . ' ' . $internal_uri, $match))
+						if (preg_match('#' . $exclusion . '#i', $this->_cache_key . ' ' . $internal_uri))
 						{
 							return true;
 						}


### PR DESCRIPTION
Pull Request for Issue #17 .

### Summary of Changes
A logger is injected into Task at creation, and into routines through ExecutedTaskEvent at runtime.

### Testing Instructions
- Tasks should be logged as expected to the scheduler log file @ `administrator/logs/joomla_scheduler.php`
- Logs for individual tasks, if enabled, should be saved to the file as specified in the configuration.


### Actual result BEFORE applying this Pull Request
No DI, ugly setup code in TaskPluginTrait etc.


### Expected result AFTER applying this Pull Request
DI, less static calls (still depends on the global Log instance to setup sub-loggers!), more succinct code.


### Documentation Changes Required
\-