### PR TITLE
Fix pagination with orphan task filter

### DIFF
--- a/administrator/components/com_scheduler/src/Model/TasksModel.php
+++ b/administrator/components/com_scheduler/src/Model/TasksModel.php
@@ -19,6 +19,7 @@ use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\CMS\Object\CMSObject;
 use Joomla\Component\Scheduler\Administrator\Helper\SchedulerHelper;
+use Joomla\Component\Scheduler\Administrator\Task\TaskOption;
 use Joomla\Database\DatabaseQuery;
 use Joomla\Database\ParameterType;
 use Joomla\Database\QueryInterface;
@@ -170,6 +171,33 @@ class TasksModel extends ListModel
 			$match = "%$title%";
 			$query->where($db->qn('a.title') . ' LIKE :match')
 				->bind(':match', $match);
+		}
+
+		// Filter orphaned (-1: exclude, 0: include, 1: only) ----
+		$filterOrphaned = (int) $this->getState('filter.orphaned');
+
+		if ($filterOrphaned !== 0)
+		{
+			$filterCount++;
+			$taskOptions = SchedulerHelper::getTaskOptions();
+
+			// Array of all active routine ids
+			$activeRoutines = array_map(
+				static function (TaskOption $taskOption): string
+				{
+					return $taskOption->type;
+				},
+				$taskOptions->options
+			);
+
+			if ($filterOrphaned === -1)
+			{
+				$query->whereIn($db->quoteName('type'), $activeRoutines, ParameterType::STRING);
+			}
+			else
+			{
+				$query->whereNotIn($db->quoteName('type'), $activeRoutines, ParameterType::STRING);
+			}
 		}
 
 		// Filter over state ----
@@ -383,24 +411,6 @@ class TasksModel extends ListModel
 		if ($listOrder == 'j.type_title')
 		{
 			$responseList = ArrayHelper::sortObjects($responseList, 'safeTypeTitle', $listDirectionN, true, false);
-		}
-
-		// Filter orphaned (-1: exclude, 0: include, 1: only) ----
-		// ! This breaks pagination at the moment [@todo: fix]
-		$filterOrphaned = (int) $this->getState('filter.orphaned');
-
-		if ($filterOrphaned !== 0)
-		{
-			$responseList = array_values(
-				array_filter(
-					$responseList,
-					static function (object $c) use ($filterOrphaned) {
-						$isOrphan = !isset($c->taskOption);
-
-						return $filterOrphaned === 1 ? $isOrphan : !$isOrphan;
-					}
-				)
-			);
 		}
 
 		return $responseList;

--- a/administrator/components/com_scheduler/src/Model/TasksModel.php
+++ b/administrator/components/com_scheduler/src/Model/TasksModel.php
@@ -230,8 +230,6 @@ class TasksModel extends ListModel
 				->bind(':type', $typeFilter);
 		}
 
-		// @todo: Filter over trigger
-
 		// Filter over exit code ----
 		$exitCode = $this->getState('filter.last_exit_code');
 


### PR DESCRIPTION
### Summary of Changes
Pagination in the task manager was broken because we were filtering out orphaned tasks from a limited list. To solve this, we could either filter out orphans from a fully loaded tasks list or do the filtering within the query by passing all active routines queries through task plugins. I chose the latter approach, which should fix this issue.

### Testing Instructions
Test the pagination by adding items, orphaning some creating tasks by disabling the parent plugins.


### Actual result BEFORE applying this Pull Request
Pagination is broken.


### Expected result AFTER applying this Pull Request
Pagination should work as expected.


### Documentation Changes Required
\-