### PR TITLE
Fix task queue behavior with orphaned tasks

### DIFF
--- a/administrator/components/com_scheduler/src/Model/TaskModel.php
+++ b/administrator/components/com_scheduler/src/Model/TaskModel.php
@@ -28,6 +28,7 @@ use Joomla\CMS\Table\Table;
 use Joomla\Component\Scheduler\Administrator\Helper\ExecRuleHelper;
 use Joomla\Component\Scheduler\Administrator\Helper\SchedulerHelper;
 use Joomla\Component\Scheduler\Administrator\Table\TaskTable;
+use Joomla\Component\Scheduler\Administrator\Task\TaskOption;
 use Joomla\Database\ParameterType;
 use Symfony\Component\OptionsResolver\Exception\AccessException;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
@@ -412,6 +413,18 @@ class TaskModel extends AdminModel
 		$lockQuery->update($db->quoteName(self::TASK_TABLE))
 			->set($db->quoteName('locked') . ' = :now1')
 			->bind(':now1', $now);
+
+		// Array of all active routine ids
+		$activeRoutines = array_map(
+			static function (TaskOption $taskOption): string
+			{
+				return $taskOption->type;
+			},
+			SchedulerHelper::getTaskOptions()->options
+		);
+
+		// "Orphaned" tasks are not a part of the task queue!
+		$lockQuery->whereIn($db->quoteName('type'), $activeRoutines, ParameterType::STRING);
 
 		// If directed, exclude CLI exclusive tasks
 		if (!$options['includeCliExclusive'])


### PR DESCRIPTION
### Summary of Changes
Excludes orphaned tasks from TaskModel::getTask()'s task locking query so don't end up acquiring locks/trying to run orphaned tasks.


### Testing Instructions
- Create a task
- Disable the parent plugin
- Check that the task does not "run"/there's no lock on the task in the task manager.

### Actual result BEFORE applying this Pull Request
Orphaned tasks are locked and triggered.


### Expected result AFTER applying this Pull Request
Orphaned tasks are excluded from the task queue.


### Documentation Changes Required
\-
